### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/brug/Cargo.toml
+++ b/brug/Cargo.toml
@@ -5,6 +5,7 @@ categories = ["rpc"]
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+repository = "https://github.com/cijber/brug/"
 
 [dependencies]
 brug-macros = { version = "0.1.0", optional = true, path = "../brug-macros" }


### PR DESCRIPTION
allow crates.io, rust-digger and others to link to it